### PR TITLE
Add jrnl.plugins to the list of installed packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     name = "jrnl",
     version = get_version(),
     description = "A command line journal application that stores your journal in a plain text file",
-    packages = ['jrnl'],
+    packages = ['jrnl','jrnl.plugins'],
     install_requires = [
         "pyxdg>=0.19",
         "parsedatetime>=1.2",


### PR DESCRIPTION
At the moment installing jrnl 2.0rc1 doesn't work because it doesn't install the plugins.  This patch fixes that.