### PR TITLE
fix issues #316 and #317

### DIFF
--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -8,6 +8,7 @@ from . import time
 import codecs
 import re
 from datetime import datetime
+import dateutil.parser
 import sys
 try:
     from Crypto.Cipher import AES

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -112,6 +112,18 @@ class Journal(object):
     def _parse(self, journal_txt):
         """Parses a journal that's stored in a string and returns a list of entries"""
 
+        def get_date_length(myline):
+            j=''
+            print 'myproc line is: ' + myline
+            for i in [x for x in myline.split(' ') ]:
+                try:
+                    dateutil.parser.parse(j+' ' +i)
+                    j=j+' ' +i
+                except:
+                    break
+            print 'j is ' + j
+            return len(j.strip())
+
         # Entries start with a line that looks like 'date title' - let's figure out how
         # long the date will be by constructing one
         date_length = len(datetime.today().strftime(self.config['timeformat']))
@@ -123,6 +135,7 @@ class Journal(object):
         for line in journal_txt.splitlines():
             line = line.rstrip()
             try:
+                date_length=get_date_length(line)
                 # try to parse line as date => new entry begins
                 new_date = datetime.strptime(line[:date_length], self.config['timeformat'])
 

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -115,14 +115,12 @@ class Journal(object):
 
         def get_date_length(myline):
             j=''
-            print 'myproc line is: ' + myline
             for i in [x for x in myline.split(' ') ]:
                 try:
                     dateutil.parser.parse(j+' ' +i)
                     j=j+' ' +i
                 except:
                     break
-            print 'j is ' + j
             return len(j.strip())
 
         # Entries start with a line that looks like 'date title' - let's figure out how

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -114,14 +114,14 @@ class Journal(object):
         """Parses a journal that's stored in a string and returns a list of entries"""
 
         def get_date_length(myline):
-            j=''
+            tmpdate=''
             for i in [x for x in myline.split(' ') ]:
                 try:
-                    dateutil.parser.parse(j+' ' +i)
-                    j=j+' ' +i
+                    dateutil.parser.parse(tmpdate + ' ' + i)
+                    tmpdate = tmpdate + ' ' + i
                 except:
                     break
-            return len(j.strip())
+            return len(tmpdate.strip())
 
         # Entries start with a line that looks like 'date title' - let's figure out how
         # long the date will be by constructing one

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -256,14 +256,14 @@ def run(manual_args=None):
     elif args.encrypt is not False:
         encrypt(journal, filename=args.encrypt)
         # Not encrypting to a separate file: update config!
-        if not args.encrypt:
+        if not args.encrypt or args.encrypt == config['journal']:
             update_config(original_config, {"encrypt": True}, journal_name, force_local=True)
             install.save_config(original_config, config_path=CONFIG_PATH)
 
     elif args.decrypt is not False:
         decrypt(journal, filename=args.decrypt)
         # Not decrypting to a separate file: update config!
-        if not args.decrypt:
+        if not args.decrypt or args.decrypt == config['journal']:
             update_config(original_config, {"encrypt": False}, journal_name, force_local=True)
             install.save_config(original_config, config_path=CONFIG_PATH)
 


### PR DESCRIPTION
I had created a fix to resolve the problem when the date format is of variable length.  I had tested with different dates, and it is working fine.  
I am using the same date format as specified in issue #317 
  "timeformat": "%A, %d %b %Y, %H:%M",


$ jrnl 2014-01-22: test0-1
[Entry added to default journal]

$ jrnl --short
Wednesday, 22 Jan 2014, 09:00 test0-1
Saturday, 06 Dec 2014, 06:31 test1
Saturday, 06 Dec 2014, 06:31 test2
Saturday, 06 Dec 2014, 06:36 test3

$ jrnl 2014-01-22: test0-2
[Entry added to default journal]

$ jrnl 2014-04-22: test0-2
[Entry added to default journal]

$ jrnl --short
Wednesday, 22 Jan 2014, 09:00 test0-1
Wednesday, 22 Jan 2014, 09:00 test0-2
Tuesday, 22 Apr 2014, 09:00 test0-2
Saturday, 06 Dec 2014, 06:31 test1
Saturday, 06 Dec 2014, 06:31 test2
Saturday, 06 Dec 2014, 06:36 test3
$


There is also a fix for encrypt flag not being toggled when we specify the journal name in the --encrypt/--decrypt.
