### PR TITLE
Correct issue #259, also fix issue with specifying DayOne journals in install

### DIFF
--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -58,7 +58,10 @@ class DayOne(Journal.Journal):
                 if not hasattr(entry, "uuid"):
                     entry.uuid = uuid.uuid1().hex
                 utc_time = datetime.utcfromtimestamp(time.mktime(entry.date.timetuple()))
-                filename = os.path.join(self.config['journal'], "entries", entry.uuid + ".doentry")
+                # make sure to upper() the uuid since uuid.uuid1 returns a lowercase string by default
+                # while dayone uses uppercase by default. On fully case preserving filesystems (e.g.
+                # linux) this results in duplicated entries when we save the file
+                filename = os.path.join(self.config['journal'], "entries", entry.uuid.upper() + ".doentry")
                 entry_plist = {
                     'Creation Date': utc_time,
                     'Starred': entry.starred if hasattr(entry, 'starred') else False,

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -87,7 +87,8 @@ def install_jrnl(config_path='~/.jrnl_config'):
     except OSError:
         pass
 
-    open(default_config['journals']['default'], 'a').close()  # Touch to make sure it's there
+    if not os.path.isdir(path):  # if it's a directory and exists (e.g. a DayOne journal, let it be)
+        open(default_config['journals']['default'], 'a').close()  # Touch to make sure it's there
 
     # Write config to ~/.jrnl_conf
     with open(config_path, 'w') as f:


### PR DESCRIPTION
Fix two issues with DayOne compatibility:

**Duplicate entries when using Linux to edit DayOne journals**
Python's uuid.uuid1 returns a lowercase uuid string by default, but DayOne
saves it's filenames using an uppercase UUID by default.

On OS X (and I believe windows) filesystems case is preserved, but not
enforced, so using jrnl on a DayOne jrnl file works as expected.  On Linux
however, filesystem case is strictly enforced. As a result when jrnl and DayOne
interact duplicate files get created--one copy with uppercase UUIDs and one
with lowercase.

**Installer doesn't finish if you point it an an existing DayOne journal**
If you specify the top-level diectory of your DayOne journal during install
jrnl dies because it is expecting a file.
