### PR TITLE
Bug fix for arguments with quotes for the editor config value. Fixes #322

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -18,7 +18,7 @@ The configuration file is a simple JSON file with the following options and can 
 - ``journals``
       paths to your journal files
 - ``editor``
-    if set, executes this command to launch an external editor for writing your entries, e.g. ``vim``. Some editors require special options to work properly, see :doc:`FAQ <recipes>` for details.
+    if set, executes this command to launch an external editor for writing your entries, e.g. ``vim``. Some editors require special options to work properly, see :doc:`FAQ <recipes>` for details. This value can either be a string such as the earlier ``"editor": "vim"`` example or ``"editor": ["vim", "+set ft=markdown"]`` if you want to pass arguments to the editor.
 - ``encrypt``
     if ``true``, encrypts your journal using AES.
 - ``tagsymbols``

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -130,7 +130,9 @@ def get_text_from_editor(config, template=""):
     with codecs.open(tmpfile, 'w', "utf-8") as f:
         if template:
             f.write(template)
-    subprocess.call(config['editor'].split() + [tmpfile])
+    editor = config['editor']
+    args = editor if isinstance(editor, list) else editor.split()
+    subprocess.call(args + [tmpfile])
     with codecs.open(tmpfile, "r", "utf-8") as f:
         raw = f.read()
     os.remove(tmpfile)


### PR DESCRIPTION
I came across the same issue that was described in #322. I didn't particularly like the solution presented as it was using regular expressions when the subprocess module can already solve this. Instead, I just allow the `editor` config value to be either a string or a list. When it is a string, it does the `editor.split()` like it was doing before, but when it is a list, it just uses that.

Here is what my config value was that was causing it to fail:

```js
{
  "editor": "vim +'set ft=markdown'"
}
```

It was splitting on whitespace so the arguments ended up being: `["vim", "+'set", "ft=markdown'"]` which obviously isn't correct.

Now the fixed config with arguments can now be:
```js
{
  "editor": ["vim", "+set ft=markdown"]
}
```

And of course the original

```js
{
  "editor": "vim --some-arg-here"
}
```

will still work.

I tried to update the docs but don't know if there are any more places you wanted it updated.

Hopefully you like the solution. Let me know if there's anything that needs changed. Cheers!