### PR TITLE
Fix: DayOne mixed-case tags don't work

### DIFF
--- a/features/data/journals/dayone.dayone/entries/044F3747A38546168B572C2E3F217FA2.doentry
+++ b/features/data/journals/dayone.dayone/entries/044F3747A38546168B572C2E3F217FA2.doentry
@@ -24,7 +24,7 @@
 	<key>Tags</key>
 	<array>
 		<string>work</string>
-		<string>play</string>
+		<string>PLaY</string>
 	</array>
 	<key>Time Zone</key>
 	<string>America/Los_Angeles</string>

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -69,3 +69,12 @@ Feature: Zapped bugs should stay dead.
 			2014-04-24 09:00 Ran 6.2 miles today in 1:02:03.
 			| I'm feeling sore because I forgot to stretch.
 			"""
+
+    Scenario: DayOne tag searching should work with tags containing a mixture of upper and lower case.
+        # https://github.com/maebert/jrnl/issues/354
+        Given we use the config "dayone.yaml"
+        When we run "jrnl @plAy"
+        Then the output should contain
+            """
+            2013-05-17 11:39 This entry has tags!
+            """

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -53,7 +53,7 @@ class DayOne(Journal.Journal):
                     title, body = (raw[:sep.end()], raw[sep.end():]) if sep else (raw, "")
                     entry = Entry.Entry(self, date, title, body, starred=dict_entry["Starred"])
                     entry.uuid = dict_entry["UUID"]
-                    entry.tags = [self.config['tagsymbols'][0] + tag for tag in dict_entry.get("Tags", [])]
+                    entry.tags = [self.config['tagsymbols'][0] + tag.lower() for tag in dict_entry.get("Tags", [])]
 
                     self.entries.append(entry)
         self.sort()


### PR DESCRIPTION
When filtering on DayOne tags that contain upper case, no entries are
returned. maebert/jrnl#354