### PR TITLE
Make line wrapping more clever about whitespace

### DIFF
--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -50,8 +50,9 @@ class Entry:
             body = "\n".join([
                     textwrap.fill(line,
                         self.journal.config['linewrap'],
-                        initial_indent="| ",
-                        subsequent_indent="| ") or "|"
+                        initial_indent=self.journal.config['indent'] + " ",
+                        subsequent_indent=self.journal.config['indent'] + " ")
+                            or self.journal.config['indent']
                     for line in self.body.rstrip(" \n").splitlines()
                 ])
         else:

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -48,11 +48,10 @@ class Entry:
         if not short and self.journal.config['linewrap']:
             title = textwrap.fill(date_str + " " + self.title, self.journal.config['linewrap'])
             body = "\n".join([
-                    textwrap.fill((line + " ") if (len(line) == 0) else line,
+                    textwrap.fill(line,
                         self.journal.config['linewrap'],
                         initial_indent="| ",
-                        subsequent_indent="| ",
-                        drop_whitespace=False)
+                        subsequent_indent="| ") or "|"
                     for line in self.body.rstrip(" \n").splitlines()
                 ])
         else:

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -29,6 +29,7 @@ class Journal(object):
             'tagsymbols': '@',
             'highlight': True,
             'linewrap': 80,
+            'indent': "|"
         }
         self.config.update(kwargs)
         # Set up date parser


### PR DESCRIPTION
This PR fixes #222, which has been bugging me forever. It also makes the line indentation character configurable, so you can put the BOX DRAWINGS LIGHT VERTICAL unicode character (│) in your `~/.jrnl.config`:

```json
{
  "linewrap": 79,
  "indent": "│",
}
```
This makes the jrnl output look pretty slick, assuming your font/terminal supports unicode characters.