### PR TITLE
Fix for getpass on Windows

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -28,7 +28,12 @@ log = logging.getLogger(__name__)
 
 def getpass(prompt="Password: "):
     if not TEST:
-        return gp.getpass(prompt)
+        try:
+            passwd = gp.getpass(prompt)
+        except TypeError:
+            passwd = gp.getpass(prompt.encode('ascii', 'ignore'))
+
+        return passwd
     else:
         return py23_input(prompt)
 


### PR DESCRIPTION
I've opened the issue #392, which I'm not able to use --encrypt on Windows, because I get a 'must be char, not unicode' error.

This is the fix for that... Works beautifully on a Windows 7!