### PR TITLE
Support unicode and userdir expansion in config during 2.0 upgrade

### DIFF
--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -10,6 +10,7 @@ import os
 
 def backup(filename, binary=False):
     util.prompt("  Created a backup at {}.backup".format(filename))
+    filename = os.path.expanduser(os.path.expandvars(filename))
     with open(filename, 'rb' if binary else 'r') as original:
         contents = original.read()
     with open(filename + ".backup", 'wb' if binary else 'w') as backup:

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -6,6 +6,7 @@ from . import util
 from .EncryptedJournal import EncryptedJournal
 import sys
 import os
+import codecs
 
 
 def backup(filename, binary=False):
@@ -18,7 +19,7 @@ def backup(filename, binary=False):
 
 
 def upgrade_jrnl_if_necessary(config_path):
-    with open(config_path) as f:
+    with codecs.open(config_path, "r", "utf-8") as f:
         config_file = f.read()
     if not config_file.strip().startswith("{"):
         return


### PR DESCRIPTION
Fixes:
  - I use a unicode character in my `~/.jrnl_config` which breaks the upgrade check, fixed by using `codecs.open` on the config file.
  - I've manually set my journal paths as `~/jrnl/default.txt` which was working fine for me in 1.0, but the upgrade to 2.0 wasn't expanding that tilde.

Fixes #406 