### PR TITLE
Clean up text wrapping once and for all

### DIFF
--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -78,11 +78,11 @@ class Entry:
             title = textwrap.fill(date_str + " " + self.title, self.journal.config['linewrap'])
             body = "\n".join([
                 textwrap.fill(
-                    (line + " ") if (len(line) == 0) else line,
+                    line,
                     self.journal.config['linewrap'],
                     initial_indent="| ",
                     subsequent_indent="| ",
-                    drop_whitespace=True)
+                    drop_whitespace=True) or "| "
                 for line in self.body.rstrip(" \n").splitlines()
             ])
         else:


### PR DESCRIPTION
The current behavior of text wrapping continues to be borken, despite my previous PR #376 against the master branch. ***Please*** read this PR's code more closely, and you'll see that it solves *all* the pretty printed text wrapping issues, very pythonically I think, and fixes #222 more simply than any other existing fix I've seen, such as 060565c.

After this PR, with perfect whitespace and indent handling:
![image](https://cloud.githubusercontent.com/assets/908201/12561288/493fff0a-c36d-11e5-8426-1451b0e1bce9.png)

Before, on the current 2.0-rc1 branch, with `drop_whitespace=True`:
![image](https://cloud.githubusercontent.com/assets/908201/12561595/0032630a-c36f-11e5-8620-fe0e0565a355.png)

Before, on the master (1.0) branch, with `drop_whitespace=False`:
![image](https://cloud.githubusercontent.com/assets/908201/12561224/f3bb8590-c36c-11e5-87bd-31a353bda060.png)