### PR TITLE
Fully strip title and body after SENTENCE_SPLITTER search

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -209,4 +209,4 @@ def split_title(text):
     punkt = SENTENCE_SPLITTER.search(text)
     if not punkt:
         return text, ""
-    return text[:punkt.end()].rstrip(), text[punkt.end():].lstrip()
+    return text[:punkt.end()].strip(), text[punkt.end():].strip()


### PR DESCRIPTION
This fixes the problem where an exported entry will have extra whitespace depending on if it was the last entry or a previous entry.

For example, a git hook that commits changes will always commit a new whitespace change for the previous entry with every new entry.