### PR TITLE
User defined indent character

### DIFF
--- a/features/data/configs/basic.yaml
+++ b/features/data/configs/basic.yaml
@@ -9,3 +9,4 @@ linewrap: 80
 tagsymbols: "@"
 template: false
 timeformat: "%Y-%m-%d %H:%M"
+indent_character: "|"

--- a/features/data/configs/bug153.yaml
+++ b/features/data/configs/bug153.yaml
@@ -10,3 +10,4 @@ password: ''
 tagsymbols: '@'
 template: false
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/bug343.yaml
+++ b/features/data/configs/bug343.yaml
@@ -10,3 +10,4 @@ journals:
 linewrap: 80
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/dayone.yaml
+++ b/features/data/configs/dayone.yaml
@@ -10,3 +10,4 @@ linewrap: 80
 password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/empty_folder.yaml
+++ b/features/data/configs/empty_folder.yaml
@@ -10,3 +10,4 @@ linewrap: 80
 password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/encrypted.yaml
+++ b/features/data/configs/encrypted.yaml
@@ -10,3 +10,4 @@ linewrap: 80
 password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/encrypted_old.yaml
+++ b/features/data/configs/encrypted_old.yaml
@@ -8,3 +8,4 @@ journals:
 linewrap: 80
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/markdown-headings-335.yaml
+++ b/features/data/configs/markdown-headings-335.yaml
@@ -10,3 +10,4 @@ linewrap: 80
 password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/multiple.yaml
+++ b/features/data/configs/multiple.yaml
@@ -13,3 +13,4 @@ linewrap: 80
 password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/tags-216.yaml
+++ b/features/data/configs/tags-216.yaml
@@ -10,3 +10,4 @@ linewrap: 80
 password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/tags-237.yaml
+++ b/features/data/configs/tags-237.yaml
@@ -10,3 +10,4 @@ linewrap: 80
 password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/features/data/configs/tags.yaml
+++ b/features/data/configs/tags.yaml
@@ -10,3 +10,4 @@ linewrap: 80
 password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -78,11 +78,11 @@ class Entry:
             title = textwrap.fill(date_str + " " + self.title, self.journal.config['linewrap'])
             body = "\n".join([
                 textwrap.fill(
-                    (line + " ") if (len(line) == 0) else line,
+                    line,
                     self.journal.config['linewrap'],
                     initial_indent="| ",
                     subsequent_indent="| ",
-                    drop_whitespace=True)
+                    drop_whitespace=True) or "| "
                 for line in self.body.rstrip(" \n").splitlines()
             ])
         else:

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -74,15 +74,16 @@ class Entry:
         """Returns a pretty-printed version of the entry.
         If short is true, only print the title."""
         date_str = self.date.strftime(self.journal.config['timeformat'])
+        indent = self.journal.config['indent_character'].rstrip() + " "
         if not short and self.journal.config['linewrap']:
             title = textwrap.fill(date_str + " " + self.title, self.journal.config['linewrap'])
             body = "\n".join([
                 textwrap.fill(
                     line,
                     self.journal.config['linewrap'],
-                    initial_indent="| ",
-                    subsequent_indent="| ",
-                    drop_whitespace=True) or "| "
+                    initial_indent=indent,
+                    subsequent_indent=indent,
+                    drop_whitespace=True) or indent
                 for line in self.body.rstrip(" \n").splitlines()
             ])
         else:

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -26,6 +26,7 @@ class Journal(object):
             'tagsymbols': '@',
             'highlight': True,
             'linewrap': 80,
+            'indent_character': '|',
         }
         self.config.update(kwargs)
         # Set up date parser

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -54,6 +54,7 @@ default_config = {
     'tagsymbols': '@',
     'highlight': True,
     'linewrap': 79,
+    'indent_character': '|',
 }
 
 


### PR DESCRIPTION
I really like unicode box characters... This PR allows the user to define what character to use for the indent. I like the light vertical box char -- on my terminal, it displays as an unbroken line on the left margin -- much nicer than the pipe char.