### PR TITLE
Fix failing behave tests

### DIFF
--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -5,7 +5,8 @@ import os
 import codecs
 import json
 import keyring
-keyring.set_keyring(keyring.backends.file.PlaintextKeyring())
+import keyrings
+keyring.set_keyring(keyrings.alt.file.PlaintextKeyring())
 try:
     from io import StringIO
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,7 @@ setup(
         "six>=1.6.1",
         "tzlocal>=1.1",
         "keyring>=3.3",
+        "keyrings.alt>=1.3",
     ] + [p for p, cond in conditional_dependencies.items() if cond],
     extras_require = {
         "encrypted": "pycrypto>=2.6"


### PR DESCRIPTION
The keyring package broke backward compatibility in version 8.0 by
moving some keyring backends to another package, keyrings.alt, as
documented in the [changelog](https://pythonhosted.org/keyring/history.html#id22).

This change broke behave tests which were trying to use
keyring.backends.file.PlaintextKeyring - no longer existing in keyring
package.

This commit adds the keyrings.alt package as dependency so that the
PlaintextKeyring class can be used.