### PR TITLE
Fix behave tests by adding asteval python dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         "keyring>=7.3",
         "passlib>=1.6.2",
         "pyxdg>=0.25",
+        "asteval>=0.9.8",
     ] + [p for p, cond in conditional_dependencies.items() if cond],
     long_description=__doc__,
     entry_points={


### PR DESCRIPTION
Behave tests were failing in `2.0-rc1` branch with 
```
ImportError: No module named 'asteval'
```

This commit adds the `asteval` dependency to `setup.py` to fix the failing tests. I chose the required asteval by setting it to my current installed version, because I didn't know what other version to put there. Feel free to change it.

Behave still fails for python 2.7, but that seems to be an unrelated issue.