### PR TITLE
Fix python2 error in template_explorer.py

### DIFF
--- a/jrnl/plugins/template_exporter.py
+++ b/jrnl/plugins/template_exporter.py
@@ -36,7 +36,7 @@ def __exporter_from_file(template_file):
     """Create a template class from a file"""
     name = os.path.basename(template_file).replace(".template", "")
     template = Template.from_file(template_file)
-    return type("{}Exporter".format(name.title()), (GenericTemplateExporter, ), {
+    return type(str("{}Exporter".format(name.title())), (GenericTemplateExporter, ), {
         "names": [name],
         "extension": template.extension,
         "template": template


### PR DESCRIPTION
If template_explorer.py was imported in python2, it would fail because
it uses unicode_literals which would ultimately cause passing an unicode
string as the first argument to the 'type' built-in function.

This commit fixes this by converting the unicode to string before it is
passed to the 'type' function.

Fixes #456