### PR TITLE
Catch keyboard interrupt when opening journal

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -206,7 +206,11 @@ def run(manual_args=None):
             mode_compose = False
 
     # This is where we finally open the journal!
-    journal = Journal.open_journal(journal_name, config)
+    try:
+        journal = Journal.open_journal(journal_name, config)
+    except KeyboardInterrupt:
+        util.prompt("[Interrupted while opening journal]".format(journal_name))
+        sys.exit(1)
 
     # Import mode
     if mode_import:


### PR DESCRIPTION
If the journal is encrypted, jrnl asks for a password using the
getpass.getpass function. If user presses the keyboard interrupt (e.g.
ctrl+c) during the password prompt, jrnl crashes and prints a stack
trace. This however is not very user friendly.

This commit adds a check for KeyboardInterrupt Exception and prints a
message whenever this exception occurs and exits. Stack is no longer
printed.

Fixes #450