### PR TITLE
Remove --use-mirrors switch from travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.3"
   - "3.4"
 install:
-  - "pip install -e . --use-mirrors"
+  - "pip install -e ."
   - "pip install -q behave"
 # command to run tests
 script:


### PR DESCRIPTION
The --use-mirrors pip switch [does not work](https://pip.pypa.io/en/stable/news/) since pip 7.0.0. This caused
travis builds to fail.

This commit removes the --use-mirrors switch.