### PR TITLE
define raw_input() for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -10,9 +9,15 @@ python:
   - "nightly"
 install:
   - "pip install -e ."
+  - "pip install flake8"
   - "pip install pycrypto>=2.6"
   - "pip install -q behave"
-# command to run tests
+# commands to run tests
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
  - python --version
  - behave

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,10 @@ try:
     readline_available = True
 except ImportError:
     readline_available = False
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -167,8 +171,9 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Topic :: Office/Business :: News/Diary",
         "Topic :: Text Processing"
     ],


### PR DESCRIPTION
Also, dropped Python 3.3 from the testing because it goes [EOL](https://docs.python.org/devguide/index.html#branchstatus) next month and added Python 3.5 and 3.6.