### PR TITLE
Order entries

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -77,6 +77,10 @@ everything that happened from the start of last year to the start of last march.
 
     jrnl -starred
 
+and to order them descendantly by date ::
+
+    jrnl -desc
+
 Using Tags
 ----------
 

--- a/features/core.feature
+++ b/features/core.feature
@@ -53,6 +53,18 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl -on 2013-06-10 --short"
         Then the output should be "2013-06-10 15:40 Life is good."
 
+    Scenario: -desc displays the entries descendantly by date
+        Given we use the config "basic.yaml"
+        When we run "jrnl --desc"
+        Then the output should be 
+            """
+            2013-06-10 15:40 Life is good.
+            | But I'm better.
+
+            2013-06-09 15:39 My first entry.
+            | Everything is alright
+            """
+
     Scenario: -s displays the short version of entries (only the title)
         Given we use the config "basic.yaml"
         When we run "jrnl -on 2013-06-10 -s"

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -179,8 +179,8 @@ class Journal(object):
         If strict is True, all tags must be present in an entry. If false, the
         entry is kept if any tag is present."""
         self.search_tags = set([tag.lower() for tag in tags])
-        end_date = time.parse(end_date, inclusive=True)
-        start_date = time.parse(start_date)
+        end_date = time.parse(end_date, inclusive=True, default_hour=self.config['default_hour'], default_minute=self.config['default_minute'], dayfirst=self.config['day_first'])
+        start_date = time.parse(start_date, default_hour=self.config['default_hour'], default_minute=self.config['default_minute'], dayfirst=self.config['day_first'])
 
         # If strict mode is on, all tags have to be present in entry
         tagged = self.search_tags.issubset if strict else self.search_tags.intersection
@@ -208,7 +208,7 @@ class Journal(object):
         if not date:
             colon_pos = first_line.find(": ")
             if colon_pos > 0:
-                date = time.parse(raw[:colon_pos], default_hour=self.config['default_hour'], default_minute=self.config['default_minute'])
+                date = time.parse(raw[:colon_pos], default_hour=self.config['default_hour'], default_minute=self.config['default_minute'], dayfirst=self.config['day_first'])
                 if date:  # Parsed successfully, strip that from the raw text
                     starred = raw[:colon_pos].strip().endswith("*")
                     raw = raw[colon_pos + 1:].strip()

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -122,10 +122,11 @@ class Journal(object):
     def __unicode__(self):
         return self.pprint()
 
-    def pprint(self, short=False):
+    def pprint(self, short=False, desc=False):
         """Prettyprints the journal's entries"""
         sep = "\n"
-        pp = sep.join([e.pprint(short=short) for e in self.entries])
+        sorted_entries = sorted(self.entries, key=lambda entry: entry.date, reverse=desc)
+        pp = sep.join([e.pprint(short=short) for e in sorted_entries])
         if self.config['highlight']:  # highlight tags
             if self.search_tags:
                 for tag in self.search_tags:

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -188,7 +188,7 @@ def run(manual_args=None):
     if mode_compose and partial_raw[1].strip() == '':
         if not sys.stdin.isatty():
             # Piping data into jrnl
-            raw = partial_raw + ': ' + util.py23_read()
+            raw = partial_raw[0] + ': ' + util.py23_read()
         elif config['editor']:
             template = ""
             if config['template']:
@@ -197,10 +197,10 @@ def run(manual_args=None):
                 except:
                     util.prompt("[Could not read template at '']".format(config['template']))
                     sys.exit(1)
-            raw = partial_raw + ': ' + util.get_text_from_editor(config, template)
+            raw = partial_raw[0] + ': ' + util.get_text_from_editor(config, template)
         else:
             try:
-                raw = partial_raw + ': ' + util.py23_read("[Compose Entry; " + _exit_multiline_code + " to finish writing]\n")
+                raw = partial_raw[0] + ': ' + util.py23_read("[Compose Entry; " + _exit_multiline_code + " to finish writing]\n")
             except KeyboardInterrupt:
                 util.prompt("[Entry NOT saved to journal.]")
                 sys.exit(0)

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -153,7 +153,7 @@ def run(manual_args=None):
 
     # If the first textual argument points to a journal file,
     # use this!
-    first_arg = args.text[0].replace(':', '')
+    first_arg = args.text[0].replace(':', '') if len(args.text) > 0 else None
     journal_name = first_arg if (args.text and first_arg in config['journals']) else 'default'
 
     if journal_name is not 'default':

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -153,7 +153,8 @@ def run(manual_args=None):
 
     # If the first textual argument points to a journal file,
     # use this!
-    journal_name = args.text[0] if (args.text and args.text[0] in config['journals']) else 'default'
+    first_arg = args.text[0].replace(':', '')
+    journal_name = first_arg if (args.text and first_arg in config['journals']) else 'default'
 
     if journal_name is not 'default':
         args.text = args.text[1:]

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -38,6 +38,7 @@ def parse_args(args=None):
     reading.add_argument('-on', dest='on_date', metavar="DATE", help='View entries on this date')
     reading.add_argument('-and', dest='strict', action="store_true", help='Filter by tags using AND (default: OR)')
     reading.add_argument('-starred', dest='starred', action="store_true", help='Show only starred entries')
+    reading.add_argument('-desc', dest='desc', action="store_true", help='Order entries downwards')
     reading.add_argument('-n', dest='limit', default=None, metavar="N", help="Shows the last n entries matching the filter. '-n 3' and '-3' have the same effect.", nargs="?", type=int)
 
     exporting = parser.add_argument_group('Export / Import', 'Options for transmogrifying your journal')
@@ -238,13 +239,15 @@ def run(manual_args=None):
                        starred=args.starred)
         journal.limit(args.limit)
 
+    desc = args.desc if args.desc is not None else False
+
     # Reading mode
     if not mode_compose and not mode_export and not mode_import:
-        print(util.py2encode(journal.pprint()))
+        print(util.py2encode(journal.pprint(desc=desc)))
 
     # Various export modes
     elif args.short:
-        print(util.py2encode(journal.pprint(short=True)))
+        print(util.py2encode(journal.pprint(short=True, desc=desc)))
 
     elif args.tags:
         print(util.py2encode(plugins.get_exporter("tags").export(journal)))

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -183,10 +183,12 @@ def run(manual_args=None):
     else:
         _exit_multiline_code = "press Ctrl+D"
 
-    if mode_compose and not args.text:
+    partial_raw = " ".join(args.text).split(':')
+    
+    if mode_compose and partial_raw[1].strip() == '':
         if not sys.stdin.isatty():
             # Piping data into jrnl
-            raw = util.py23_read()
+            raw = partial_raw + ': ' + util.py23_read()
         elif config['editor']:
             template = ""
             if config['template']:
@@ -195,10 +197,10 @@ def run(manual_args=None):
                 except:
                     util.prompt("[Could not read template at '']".format(config['template']))
                     sys.exit(1)
-            raw = util.get_text_from_editor(config, template)
+            raw = partial_raw + ': ' + util.get_text_from_editor(config, template)
         else:
             try:
-                raw = util.py23_read("[Compose Entry; " + _exit_multiline_code + " to finish writing]\n")
+                raw = partial_raw + ': ' + util.py23_read("[Compose Entry; " + _exit_multiline_code + " to finish writing]\n")
             except KeyboardInterrupt:
                 util.prompt("[Entry NOT saved to journal.]")
                 sys.exit(0)

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -12,7 +12,7 @@ consts.DOWParseStyle = -1  # "Monday" will be either today or the last Monday
 CALENDAR = pdt.Calendar(consts)
 
 
-def parse(date_str, inclusive=False, default_hour=None, default_minute=None):
+def parse(date_str, inclusive=False, default_hour=None, default_minute=None, dayfirst=False):
     """Parses a string containing a fuzzy date and returns a datetime.datetime object"""
     if not date_str:
         return None
@@ -24,7 +24,7 @@ def parse(date_str, inclusive=False, default_hour=None, default_minute=None):
     year_present = False
     while not date:
         try:
-            date = dateparse(date_str, default=default_date)
+            date = dateparse(date_str, default=default_date, dayfirst=dayfirst)
             if date.year == FAKE_YEAR:
                 date = datetime(datetime.now().year, date.timetuple()[1:6])
             else:


### PR DESCRIPTION
Use `-desc` to order entries descendantly by date. Fix request #396 