### PR TITLE
Update advanced.rst

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -6,7 +6,7 @@ Advanced Usage
 Configuration File
 -------------------
 
-You can configure the way jrnl behaves in a configuration file. By default, this is ``~/.jrnl_config``. If you have the ``XDG_CONFIG_HOME`` variable set, the configuration file will be saved under ``$XDG_CONFIG_HOME/jrnl``.
+You can configure the way jrnl behaves in a configuration file. By default, this is ``~/.jrnl_config``. If you have the ``XDG_CONFIG_HOME`` variable set, the configuration file will be saved as ``$XDG_CONFIG_HOME/jrnl/.jrnl_config``.
 
 .. note::
 


### PR DESCRIPTION
Update to clarify that jrnl creates .jrnl_config file under $XDG_CONFIG/jrnl/ folder (I mistakenly interpreted the original to mean the config file should be called $XDG_CONFIG/jrnl, and was super confused that jrnl did not read it).