### PR TITLE
Avoid data loss by postponing open() (#502)

### DIFF
--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -36,8 +36,6 @@ class Journal(object):
         self.search_tags = None  # Store tags we're highlighting
         self.name = name
 
-        self.open()
-
     def __len__(self):
         """Returns the number of entries"""
         return len(self.entries)

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -216,6 +216,8 @@ def run(manual_args=None):
         else:
             mode_compose = False
 
+    journal.open()
+
     # Writing mode
     if mode_compose:
         raw = " ".join(args.text).strip()


### PR DESCRIPTION
Postpone the reading of existing entries until a new entry
has been obtained and is ready to be appended to the journal.

This patch reduces the likelihood of losing entries when the
user has launched concurrent jrnl sessions to add multiple
entries. A proper solution would require locking the journal
file for the time between reading and writing, but this is
already good enough for typical interactive use cases.