### PR TITLE
Allow list of arguments instead of string in config['editor']

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -130,7 +130,12 @@ def get_text_from_editor(config, template=""):
     with codecs.open(tmpfile, 'w', "utf-8") as f:
         if template:
             f.write(template)
-    subprocess.call(config['editor'].split() + [tmpfile])
+    try:
+        iter(config['editor'])
+    except:
+        subprocess.call(config['editor'].split() + [tmpfile])
+    else:
+        subprocess.call(config['editor'] + [tmpfile])
     with codecs.open(tmpfile, "r", "utf-8") as f:
         raw = f.read()
     os.remove(tmpfile)


### PR DESCRIPTION
This helps whenever your editor commandline needs to escape spaces,
for example:

    vim -c set\ filetype=markdown

can now go in your config file as:

    { "editor": ["vim", "-c", "set filetype=markdown"] }