### PR TITLE
Added @hollystyles' fix for Issue #415

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -127,6 +127,7 @@ def load_and_fix_json(json_path):
 
 def get_text_from_editor(config, template=""):
     _, tmpfile = tempfile.mkstemp(prefix="jrnl", text=True, suffix=".txt")
+    os.close(_)
     with codecs.open(tmpfile, 'w', "utf-8") as f:
         if template:
             f.write(template)


### PR DESCRIPTION
Fixes the problem with permissions when trying to use an external editor to edit old entries on Windows.