### PR TITLE
#594 allowing template interpreter to interpret common Python commands

### DIFF
--- a/jrnl/plugins/template.py
+++ b/jrnl/plugins/template.py
@@ -39,7 +39,8 @@ class Template(object):
         return self._expand(self.blocks[block], **vars)
 
     def _eval_context(self, vars):
-        e = asteval.Interpreter(symtable=vars, use_numpy=False, writer=None)
+        e = asteval.Interpreter(use_numpy=False, writer=None)
+        e.symtable.update(vars)
         e.symtable['__last_iteration'] = vars.get("__last_iteration", False)
         return e
 


### PR DESCRIPTION
It seems like the intent in sample.template is for all templates to be able to arbitrarily execute Python commands, so I initialized the asteval Interpreter with its default commands -- referenced here: https://newville.github.io/asteval/basics.html

Alternatively, if templates should only be able to call len, we could add that to the symtable.